### PR TITLE
updates encountered while preparing the gpig tutorial for oceandata-notebooks

### DIFF
--- a/src/gpig/L2_utils.py
+++ b/src/gpig/L2_utils.py
@@ -24,7 +24,7 @@ from .rrs_inversion_pigments import rrs_inversion_pigments
 def load_data(tspan, bbox):
     '''
     Downloads one L2 PACE apparent optical properties (AOP) file that intersects the coordinate box passed in, as well as 
-    temperature and salinity files. Data files are saved to local folders named 'L2_data', 'sal_data', and 'temp_data'.
+    temperature and salinity files. Data files are saved to local folders named 'L2_rrs_data', 'sal_data', and 'temp_data'.
 
     Parameters:
     -----------
@@ -35,11 +35,11 @@ def load_data(tspan, bbox):
 
     Returns:
     --------
-    L2_path : list
+    list
         A list of file paths to a PACE L2 AOP files intersecting the passed in bounding box.
-    sal_path : string
+    string
         A single file path to a salinity file.
-    temp_path : string
+    string
         A single file path to a temperature file.
     '''
 
@@ -126,7 +126,7 @@ def estimate_inv_pigments(L2_path, sal_path, temp_path, bbox=None):
 
     Returns:
     --------
-    Xarray dataset 
+    xarray.Dataset
         Dataset containing the Chla, Chlb, Chlc, and PPC concentration at each lat/lon coordinate
     '''
 
@@ -135,14 +135,12 @@ def estimate_inv_pigments(L2_path, sal_path, temp_path, bbox=None):
     wavelength_coords = sensor_band_params.wavelength_3d.values
     
     dataset = xr.open_dataset(L2_path, group='geophysical_data')
-    rrs = dataset['Rrs']
-    rrs_unc = dataset['Rrs_unc']
+    rrs = dataset[['Rrs', 'Rrs_unc']]
 
     # Add latitude and longitude coordinates to the Rrs and Rrs uncertainty datasets
     dataset = xr.open_dataset(L2_path, group="navigation_data")
     dataset = dataset.set_coords(("longitude", "latitude"))
-    dataset_r = xr.merge((rrs, dataset.coords))
-    dataset_ru = xr.merge((rrs_unc, dataset.coords))
+    rrs = xr.merge((rrs, dataset.coords))
 
     if bbox is not None:
         w,s,e,n = bbox[0],bbox[1],bbox[2],bbox[3]
@@ -151,22 +149,12 @@ def estimate_inv_pigments(L2_path, sal_path, temp_path, bbox=None):
         print(w,s,e,n)
 
         try:
-            rrs_box = dataset_r["Rrs"].where(
+            rrs_box = rrs.where(
                 (
-                    (dataset["latitude"] > s)
-                    & (dataset["latitude"] < n)
-                    & (dataset["longitude"] < e)
-                    & (dataset["longitude"] > w)
-                ),
-                drop=True,
-            )
-
-            rrs_unc_box = dataset_ru["Rrs_unc"].where(
-                (
-                    (dataset["latitude"] > s)
-                    & (dataset["latitude"] < n)
-                    & (dataset["longitude"] < e)
-                    & (dataset["longitude"] > w)
+                    (rrs["latitude"] > s)
+                    & (rrs["latitude"] < n)
+                    & (rrs["longitude"] < e)
+                    & (rrs["longitude"] > w)
                 ),
                 drop=True,
             )
@@ -179,17 +167,7 @@ def estimate_inv_pigments(L2_path, sal_path, temp_path, bbox=None):
         e = dataset.longitude.values.max()
         w = dataset.longitude.values.min()
 
-        rrs_box = dataset_r["Rrs"].where(
-            (
-                (dataset["latitude"] > s)
-                & (dataset["latitude"] < n)
-                & (dataset["longitude"] < e)
-                & (dataset["longitude"] > w)
-            ),
-            drop=True,
-        )
-
-        rrs_unc_box = dataset_ru["Rrs_unc"].where(
+        rrs_box = rrs.where(
             (
                 (dataset["latitude"] > s)
                 & (dataset["latitude"] < n)
@@ -220,15 +198,15 @@ def estimate_inv_pigments(L2_path, sal_path, temp_path, bbox=None):
     pixels = rrs_box.number_of_lines.size * rrs_box.pixels_per_line.size
 
     # for each coordinate estimate the pigment concentrations
-    for i in range(len(rrs_box.number_of_lines)):
-        for j in range(len(rrs_box.pixels_per_line)):
+    for i in range(rrs_box.sizes["number_of_lines"]):
+        for j in range(rrs_box.sizes["pixels_per_line"]):
             # prints total number of pixels and how many have been estimated already
             sys.stdout.write('\rProgress: ' + str(progress) + '/' + str(pixels))
             sys.stdout.flush()
             progress += 1
 
-            r = rrs_box[i][j].to_numpy()
-            ru = rrs_unc_box[i][j].to_numpy()
+            r = rrs_box["Rrs"][i][j].to_numpy()
+            ru = rrs_unc_box["Rrs_unc"][i][j].to_numpy()
             sal_val = sal[i][j].values.item()
             temp_val = temp[i][j].values.item()
             if not (np.isnan(r[0]) or np.isnan(sal_val) or np.isnan(temp_val)):

--- a/src/gpig/L3_utils.py
+++ b/src/gpig/L3_utils.py
@@ -143,13 +143,12 @@ def estimate_inv_pigments(rrs_paths, sal_paths, temp_paths, bbox):
             'chla': (['lat', 'lon'], chla),
             'chlb': (['lat', 'lon'], chlb),
             'chlc': (['lat', 'lon'], chlc),
-            'ppc': (['lat', 'lon'], ppc)
+            'ppc': (['lat', 'lon'], ppc),
         },
         coords={
             'lat': box.lat.to_numpy(),
-            'lon': box.lon.to_numpy()
-        }
-
+            'lon': box.lon.to_numpy(),
+        },
     )
 
     return pigments
@@ -312,7 +311,7 @@ def _create_dataset(rrs_paths, sal_paths, temp_paths, bbox):
         rrs_data = xr.open_mfdataset(
             rrs_paths,
             combine="nested",
-            concat_dim="date"
+            concat_dim="date",
         )
         rrs = rrs_data["Rrs"].sel({"lat": slice(n, s), "lon": slice(w, e)}).mean('date')
         rrs = rrs.compute()
@@ -328,7 +327,7 @@ def _create_dataset(rrs_paths, sal_paths, temp_paths, bbox):
         sal = xr.open_mfdataset(
             sal_paths,
             combine="nested",
-            concat_dim="date"
+            concat_dim="date",
         )
         sal = sal["smap_sss"].interp(longitude=rrs.lon, latitude=rrs.lat, method='nearest').mean('date')
         sal = sal.compute()
@@ -361,8 +360,8 @@ def _create_dataset(rrs_paths, sal_paths, temp_paths, bbox):
         coords={
             "lat": rrs.lat,
             "lon": rrs.lon,
-            'wavelength': rrs.wavelength
-        }
+            'wavelength': rrs.wavelength,
+        },
     )
 
     return combined_ds

--- a/src/gpig/L3_utils.py
+++ b/src/gpig/L3_utils.py
@@ -23,7 +23,7 @@ from .rrs_inversion_pigments import rrs_inversion_pigments
 def load_data(tspan, resolution):
     '''
     Downloads Remote Sensing Reflectance (Rrs) data from the PACE Satellite, as well as salinity and temperature data (from different 
-    missions), and saves the data files to local folders named 'rrs_data', 'sal_data', and 'temp_data'.
+    missions), and saves the data files to local folders named 'L3_rrs_data', 'sal_data', and 'temp_data'.
 
     Parameters:
     -----------
@@ -34,11 +34,11 @@ def load_data(tspan, resolution):
 
     Returns:
     --------
-    rrs_paths : list
+    list
         A list containing the file path(s) to the downloaded Rrs PACE files.
-    sal_paths : list
+    list
         A list containing the file path(s) to the downloaded salinity files.
-    temp_paths : list
+    list
         A list containing the file path(s) to the downloaded temperature files.
     '''
 
@@ -100,7 +100,7 @@ def estimate_inv_pigments(rrs_paths, sal_paths, temp_paths, bbox):
 
     Returns:
     --------
-    Xarray dataset 
+    xarray.Dataset
         Dataset containing the Chla, Chlb, Chlc, and PPC concentration at each lat/lon coordinate
     '''
     
@@ -173,7 +173,7 @@ def estimate_cov_pigments(tspan, bbox):
 
     Returns:
     --------
-    Xarray dataset 
+    xarray.Dataset 
         Dataset containing the Chla, Chlb, Chlc, and PPC concentration at each lat/lon coordinate.
     '''
     
@@ -289,7 +289,7 @@ def _create_dataset(rrs_paths, sal_paths, temp_paths, bbox):
 
     Returns:
     --------
-    Xarray data array
+    xarray.Dataset
         A data array of Rrs values at each wavelength over a specified lat/lon box.
 
     Raises:

--- a/src/gpig/rrs_inversion_pigments.py
+++ b/src/gpig/rrs_inversion_pigments.py
@@ -17,8 +17,7 @@ G2 = 0.0794
 LNOT = 400  # reference lambda wavelength (nm)
 
 def rrs_inversion_pigments(Rrs, Rrs_unc, wl, temp, sal):
-    '''
-    Inversion algorithm to estimate phytoplankton pigments from Rrs spectra
+    '''Inversion algorithm to estimate phytoplankton pigments from Rrs spectra
 
     Ali Chase, University of Maine, 2017 - 2019
 
@@ -53,20 +52,20 @@ def rrs_inversion_pigments(Rrs, Rrs_unc, wl, temp, sal):
                 
     Returns:
     --------
-    pigmedian : Numpy array
+    numpy.ndarray
         Estimated pigment concentrations
-    pig_unc : Numpy Array
+    numpy.ndarray
         Uncertainties in estimated pigments,
         calculated using a Monte Carlo method that in turn uses the 
         reported uncertainties in the A and B coefficients reported
         in Chase et al. (2017). 
-    vars_units : str
+    str
         The names and units of the estimated pigments:
         chlorophyll a (Chla), chlorophyll b (Chlb), chlorophyll c1
         +c2 (Chlc12), and photoprotective carotenoids (PPC) defined
         as abcarotene+zeaxanthin+alloxanthin+diadinoxanthin. All
         pigments and uncertainties are in mg m^-3.
-    amps : Numpy array
+    numpy.ndarray
         Amplitudes of Gaussian absorption functions
         representing Chla, Chlb, Chlc12, and PPC. Can be used to derive
         updated relationships between Gaussians and HPLC pigments.
@@ -415,7 +414,8 @@ def betasw124_ZHH2009(lambda_, S, Tc, delta=0.039):
 
 
 def tempsal_corr(lambda_):
-    """ """
+    """
+    """
     p = files("gpig").joinpath("resources/Sullivan_pure_water_temp_sal.csv")
     pwts = pd.read_csv(p)
 
@@ -450,9 +450,9 @@ def get_water_iops(lambda_, T=22, S=35):
 
     Returns
     -------
-    a_sw: (array)
+    numpy.ndarray
         Absorption of seawater at each wavelength in wavel for the specified temperature and salinity values.
-    bb_sw: (array)
+    numpy.ndarray
         Backscattering of seawater at each wavelenght in wavel for the specified temperature and salinity values.
     """
     lambda_water1 = [250, 260, 270, 280, 290] + list(range(300, 551, 2))


### PR DESCRIPTION
I'm helping @aewindle110 finish up the GPig tutorial (https://github.com/nasa/oceandata-notebooks/pull/48), and encountered some issues in the package I'd like to help fix. This PR mixes a few things together (sorry!):

1. When working with a bbox, use `interp` without previously slicing on the salinity and temperature arrays. The slicing got in the way of the interpolation being able to find the nearest neighbor outside the bbox, creating unnecessary NaNs. The interpolation does not load extra data, to the slicing isn't needed.

1. The documentation correctly names the rrs data folder, and no longer identifies the return variable by name. The second part is a personal preference, but the variable name's in your function don't mean anything to the user!

1. `L2_utils.estimate_inv_pigments` now returns an `xarray.Dataset` like the one returned by the corresponding L3_utils function.